### PR TITLE
added user-configurable C++ header dir

### DIFF
--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -356,7 +356,7 @@ function initialize_instance!(C; register_boot = true)
     #user-configurable C++ runtime dirs in case nostdcxx was specified
     header_dirs = split(get(ENV, "CXXJL_HEADER_DIRS", ""), ":")
     for dir in header_dirs
-        addHeaderDir(C, dir, kind = C_System)
+        addHeaderDir(C, ascii(dir), kind = C_System)
     end
     addClangHeaders(C)
     register_boot && register_booth(C)

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -353,6 +353,11 @@ function initialize_instance!(C; register_boot = true)
     if !nostdcxx
         addStdHeaders(C)
     end
+    #user-configurable C++ runtime dirs in case nostdcxx was specified
+    header_dirs = split(get(ENV, "CXXJL_HEADER_DIRS", ""), ":")
+    for dir in header_dirs
+        addHeaderDir(C, dir, kind = C_System)
+    end
     addClangHeaders(C)
     register_boot && register_booth(C)
 end


### PR DESCRIPTION
Same motivation as in https://github.com/Keno/Cxx.jl/pull/283 but cleaner implementation.

Allows one to manually configure the C++ header search dirs in case automatic discovery was switched off using an environment variable `CXXJL_HEADER_DIRS`.

This works well on a CERN distributed file system with the following `~/.juliarc.jl`
~~~
ENV["CXXJL_HEADER_DIRS"] = "/cvmfs/cms.cern.ch/slc6_amd64_gcc493/external/gcc/4.9.3/include/c++/4.9.3/:/cvmfs/cms.cern.ch/slc6_amd64_gcc493/external/gcc/4.9.3/include/c++/4.9.3/x86_64-redhat-linux-gnu/:/usr/include"
ENV["CXXJL_NOSTDCXX"] = true
~~~