### PR TITLE
Make globals external again

### DIFF
--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -1727,10 +1727,10 @@ JL_DLLEXPORT void cleanup_cpp_env(C, cppcall_state_t *state)
     Cxx->CGM->Release();
 
     // Set all functions and globals to external linkage (MCJIT needs this ugh)
-    //for(Module::global_iterator I = jl_Module->global_begin(),
-    //        E = jl_Module->global_end(); I != E; ++I) {
-    //    I->setLinkage(llvm::GlobalVariable::ExternalLinkage);
-    //}
+    auto &jl_Module = Cxx->CGM->getModule();
+    for(auto I = jl_Module.global_begin(), E = jl_Module.global_end(); I != E; ++I) {
+       I->setLinkage(llvm::GlobalVariable::ExternalLinkage);
+    }
 
     Function *F = Cxx->CGF->CurFn;
 


### PR DESCRIPTION
Hello! Persuant to @vchuravy's suggestion in [Julia PR #31272](https://github.com/JuliaLang/julia/pull/31272), I'd like to restore some commented-out code that makes all globals external. My proposed changes in the Julia PR tweak `llvmcall` to no longer silently discard non-external linkage for globals. However, as it turns out, Cxx.jl seems to implicitly rely on `llvmcall` discarding non-external linkage. Hence this PR.

I used `Pkg.test()` to run Cxx.jl's tests. With my proposed changes, Cxx.jl's tests all pass when run on my machine using the modified version of Julia from my aforementioned PR. Cxx.jl's tests also pass when run using Julia compiled from the master branch (hopefully the CI builds will confirm that). Is there anything else I should do to test if Cxx.jl still works?