### PR TITLE
WIP: Added hook for injecting user code.

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -15,6 +15,7 @@ end
 #that contains the headers etc, use that
 BASE_JULIA_BIN = get(ENV, "BASE_JULIA_BIN", Sys.BINDIR)
 BASE_JULIA_SRC = get(ENV, "BASE_JULIA_SRC", joinpath(BASE_JULIA_BIN, "..", ".."))
+USER_SRC = get(ENV, "JULIA_CXX_USER_SRC", "empty.jl")
 
 #write a simple include file with that path
 println("writing path.jl file")
@@ -24,6 +25,9 @@ export BASE_JULIA_BIN
 
 const BASE_JULIA_SRC=$(sprint(show, BASE_JULIA_SRC))
 export BASE_JULIA_SRC
+
+const USER_SRC=$(sprint(show, USER_SRC))
+export USER_SRC
 """
 
 println("Tuning for julia installation at $BASE_JULIA_BIN with sources possibly at $BASE_JULIA_SRC")

--- a/src/Cxx.jl
+++ b/src/Cxx.jl
@@ -173,6 +173,7 @@ include("cxxmacro.jl")
 include("cxxstr.jl")
 include("utils.jl")
 include("exceptions.jl")
+include(USER_SRC)
 
 # In precompilation mode, we do still need clang, so do it manually
 __init__()

--- a/src/empty.jl
+++ b/src/empty.jl
@@ -1,0 +1,1 @@
+# intentionally empty


### PR DESCRIPTION
While Cxx.jl can be precompiled, modules that depend on it cannot.
This patch provides a hack/hook for having arbitary user code
inserted into Cxx.jl and precompiled along with it.