### PR TITLE
Fix headers not being found on macOS Catalina.

### DIFF
--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -218,9 +218,8 @@ nostdcxx = haskey(ENV,"CXXJL_NOSTDCXX")
 
 # On OS X, we just use the libc++ headers that ship with XCode
 @static if isapple() function collectStdHeaders!(headers)
-    cmd_path = strip(read(`xcode-select --print-path`, String))
-    sdk_path = joinpath(cmd_path, "SDKs", "MacOSX.sdk")
-    xcode_path = cmd_path
+    xcode_path = strip(read(`xcode-select --print-path`, String))
+    sdk_path = strip(read(`xcrun --show-sdk-path`, String))
     occursin("Xcode", xcode_path) && (xcode_path *= "/Toolchains/XcodeDefault.xctoolchain/")
     didfind = false
     lib = joinpath(xcode_path, "usr", "lib", "c++", "v1")


### PR DESCRIPTION
Using `xcrun` instead of `xcode-select` will give us the proper paths.

I haven't tested this patch against older versions of macOS. It looks like it should work on Mojave ([https://apple.stackexchange.com/questions/337940/why-is-usr-include-missing-i-have-xcode-and-command-line-tools-installed-moja](https://apple.stackexchange.com/questions/337940/why-is-usr-include-missing-i-have-xcode-and-command-line-tools-installed-moja)).

This should fix #442.