### PR TITLE
Provide override for standard headers in C++

### DIFF
--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -385,6 +385,9 @@ end
 
 function collectAllHeaders!(headers, nostdcxx)
     nostdcxx || collectStdHeaders!(headers)
+    for header in split(get(ENV, "CXXJL_HEADER_DIRS", ""), ":")
+      push!(headers, (header, C_System))
+    end
     collectClangHeaders!(headers)
     headers
 end


### PR DESCRIPTION
Using Cxx on a system like Gentoo or some supercomputers with multiple
compilers installed in non-standard locations will result in Cxx not finding
 the standard library.  This change allows users to specify where to find 
the system includes in a way that doesn't requiring forking Cxx to make
 these changes.  Since these systems are inherently non-standard, these 
changes are unlikely to be fixed with a change to `CollectLinuxHeaderPaths!` 
so providing anoverride is better.

This patch is an updated version of pull request #324 and #283 which no longer
compile with the current version of Cxx.  It also serves as a solution to the issue 
raised #315 that doesn't require a solution like VPetukhov suggested which 
essentially forks Cxx for every user with these nonstandard locations.