### PR TITLE
Move user override for standard headers to take precedence over all others

### DIFF
--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -383,10 +383,10 @@ function collectClangHeaders!(headers)
 end
 
 function collectAllHeaders!(headers, nostdcxx)
-    nostdcxx || collectStdHeaders!(headers)
     for header in split(get(ENV, "CXXJL_HEADER_DIRS", ""), ":")
         isempty(header) || push!(headers, (header, C_System))
     end
+    nostdcxx || collectStdHeaders!(headers)
     collectClangHeaders!(headers)
     headers
 end


### PR DESCRIPTION
See https://github.com/JuliaInterop/Cxx.jl/pull/448#issuecomment-569572573; the order of `headers` appears to make a difference (at least on my machine):
```julia
julia> versioninfo()
Julia Version 1.3.0
Commit 46ce4d7933 (2019-11-26 06:09 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-6.0.1 (ORCJIT, skylake)

```