### PR TITLE
Update Project.toml for compat 1.3 and not 1.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "a0b5b9ef-44b7-5148-a2d1-f6db19f3c3d2"
 version = "0.4.0"
 
 [compat]
-julia = "^1.3"
+julia = "~1.3"
 BinaryProvider = "^0.5.0"
 
 [deps]


### PR DESCRIPTION
Due to issues with Julia 1.4, use tilde operator to state compatibility with Julia [1.3.0, 1.4.0) since this is not operational on 1.4