### PR TITLE
fix typos

### DIFF
--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -1701,7 +1701,7 @@ JL_DLLEXPORT void *setup_cpp_env(CxxInstance *Cxx, void *jlfunc)
 
     Cxx->CGF->ReturnBlock = Cxx->CGF->getJumpDestInCurrentScope("return");
 
-    // setup the environment to clang's expecations
+    // setup the environment to clang's expectations
     Cxx->CGF->Builder.SetInsertPoint( b0 );
     // clang expects to alloca memory before the AllocaInsertPt
     // typically, clang would create this pointer when it started emitting the function

--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -222,7 +222,7 @@ end
 #
 # This can be considered a more fancy form of name lookup, etc. because it
 # can it can descend into template declarations, as well as having to
-# unmarshall the CppNNS structure. However, the basic functionality and
+# unmarshal the CppNNS structure. However, the basic functionality and
 # caveats named in typetranslation.jl still apply.
 #
 

--- a/src/cxxstr.jl
+++ b/src/cxxstr.jl
@@ -238,7 +238,7 @@ function ActOnStartOfFunction(C,D,ScopeIsNull = false)
 end
 function ParseFunctionStatementBody(C,D)
     if ccall((:ParseFunctionStatementBody,libcxxffi),Bool,(Ref{ClangCompiler},Ptr{Cvoid}),C,D) == 0
-        error("A failure occured while parsing the function body")
+        error("A failure occurred while parsing the function body")
     end
 end
 
@@ -435,7 +435,7 @@ end
 
 function process_body(compiler, str, global_scope = true, cxxt = false, filename=Symbol(""),line=1,col=1)
     # First we transform the source buffer by pulling out julia expressions
-    # and replaceing them by expression like __julia::var1, which we can
+    # and replacing them by expression like __julia::var1, which we can
     # later intercept in our external sema source
     # TODO: Consider if we need more advanced scope information in which
     # case we should probably switch to __julia_varN instead of putting
@@ -460,7 +460,7 @@ function process_body(compiler, str, global_scope = true, cxxt = false, filename
     # so we just write a bunch of spaces to match the
     # indentation for the first line.
     # However, due to the processing below columns are off anyway,
-    # so let's not do this until we can actually gurantee it'll be correct
+    # so let's not do this until we can actually guarantee it'll be correct
     # for _ in 1:(col-1)
     #    write(sourcebuf," ")
     # end

--- a/src/cxxtypes.jl
+++ b/src/cxxtypes.jl
@@ -7,7 +7,7 @@ struct QualType
 end
 Base.convert(::Type{Ptr{Cvoid}}, QT::QualType) = QT.ptr
 
-# All types that are recgonized as builtins
+# All types that are recognized as builtins
 const CxxBuiltinTypes = Union{Type{Bool},
     Type{UInt8},  Type{Int8},    Type{UInt16}, Type{Int16},
     Type{Int32},  Type{UInt32},  Type{Int64},  Type{UInt64},

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -87,7 +87,7 @@ function process_cxx_exception(code::UInt64, e::Ptr{Cvoid})
     error("Caught a C++ exception")
 end
 
-# Get the typename, but strip refence
+# Get the typename, but strip reference
 @generated function typename(CT, Ty)
     if Ty <: Type || Ty <: Val
         Ty = Ty.parameters[1]

--- a/src/initialization.jl
+++ b/src/initialization.jl
@@ -415,7 +415,7 @@ function setup_exception_callback()
     unsafe_store!(callback, @cfunction(process_cxx_exception,Union{},(UInt64,Ptr{Cvoid})))
 end
 
-# As an optimzation, create a generic function per compiler instance,
+# As an optimization, create a generic function per compiler instance,
 # to avoid having to create closures at the call site
 const GlobalPCHBuffer = UInt8[]
 const inited = Ref{Bool}(false)

--- a/src/typetranslation.jl
+++ b/src/typetranslation.jl
@@ -197,7 +197,7 @@ cppdecl(C,p::Type{T}) where {T<:CppEnum} = lookup_ctx(C,p.parameters[1])
 function cppdecl(C,TT::Type{CppTemplate{T,targs}}) where {T,targs}
     ctx = cppdecl(C,T)
 
-    # Do the acutal template resolution
+    # Do the actual template resolution
     cxxt = cxxtmplt(ctx)
     @assert cxxt != C_NULL
     deduced_class = specialize_template(C,cxxt,targs)


### PR DESCRIPTION
src/bootstrap.cpp
src/codegen.jl
src/cxxstr.jl
src/cxxtypes.jl
src/exceptions.jl
src/initialization.jl
src/typetranslation.jl

WON'T FIX (from patches)

```
$ grep -nr Otherwize Cxx.jl
Cxx.jl/deps/llvm_patches/0019-llvm-rL327898.patch:1114:+        // Otherwize, we find ourselves in a position where we have to do
$ grep -nr corresonding Cxx.jl
Cxx.jl/deps/llvm_patches/0023-llvm-D44892-Perf-integration.patch:453:+    // corresonding code load.
$ grep -nr dependences Cxx.jl
Cxx.jl/deps/llvm_patches/0019-llvm-rL327898.patch:967:+  // This merge induced dependences from: #1: Xn -> LD, OP, Zn
$ grep -nr reversable Cxx.jl
Cxx.jl/deps/llvm_patches/0019-llvm-rL327898.patch:291:+// achieved by selected nodes). As the conversion is reversable the original Id,
$ grep -nr sucessor Cxx.jl
Cxx.jl/deps/llvm_patches/0019-llvm-rL327898.patch:288:+// sucessor nodes, i.e. id != -1 as invalid for pruning by bit-negating (x =>
$ grep -nr temportary Cxx.jl
Cxx.jl/deps/llvm_patches/0027-llvm-D51842-win64-byval-cc.patch:118:+        // Copy the argument into a temportary spill slot
$ grep -nr thse Cxx.jl
Cxx.jl/deps/llvm_patches/0019-llvm-rL327898.patch:146:    after the latest set of backports. Fixing thse for the backport
$ grep -nr topolgical Cxx.jl
Cxx.jl/deps/llvm_patches/0019-llvm-rL327898.patch:219:+    // 0), new nodes (set to -1). If N has a topolgical id then we
$ 
```